### PR TITLE
nil parameters sent as NULL instead of erroring

### DIFF
--- a/lua/metso/connection.lua
+++ b/lua/metso/connection.lua
@@ -16,7 +16,6 @@ function Connection:_parseQuery(sql, params)
 	local i = 1
 	return sql:gsub("%?", function()
 		local param = params[i]
-		assert(not not param, "param #" .. i .. " nil in query")
 
 		i = i + 1
 
@@ -24,6 +23,8 @@ function Connection:_parseQuery(sql, params)
 			return self:_escapeString(param)
 		elseif type(param) == "number" then
 			return tostring(param)
+		elseif param == nil then
+			return "NULL"
 		else
 			error("unknown type given to sql query: " .. type(param))
 		end


### PR DESCRIPTION
There's currently no way to send NULL with the placeholder parameters, a nil variable will now be sent as NULL like how it works in PHP for example.

If the column is marked as NOT NULL it'll error there instead like it should.